### PR TITLE
QRDA 3 performance improvements, performance rate filtering

### DIFF
--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -8,6 +8,7 @@ class Validation
   field :overview_text,             type: String
   field :qrda_type,                 type: String # 1, 3, or all
   field :measure_type,              type: String # discrete, continuous, all
+  field :performance_rate_required, type: Boolean
   field :tags,                      type: Array, default: []
 
   default_scope -> { order('qrda_type ASC, name ASC') }

--- a/lib/cedar/validations.json
+++ b/lib/cedar/validations.json
@@ -6,7 +6,8 @@
             "name": "Discharge After Upload",
             "overview_text": "In this file, a randomly selected encounter or procedure had a discharge date after the file upload date. The file should be rejected.",
             "qrda_type": "1",
-            "measure_type": "all"
+            "measure_type": "all",
+            "performance_rate_required": false
         }
     },
     {
@@ -16,7 +17,8 @@
             "name": "Discharge Before Admission",
             "overview_text": "In this file, a randomly selected encounter or procedure had a discharge date before its admission date. The file should be rejected.",
             "qrda_type": "1",
-            "measure_type": "all"
+            "measure_type": "all",
+            "performance_rate_required": false
         }
     },
     {
@@ -26,7 +28,8 @@
             "name": "Incorrect Code System",
             "overview_text": "In this file, the OID of one of the existing code systems was replaced by the OID of another.  This invalidates the reported code and the file should be rejected.",
             "qrda_type": "1",
-            "measure_type": "all"
+            "measure_type": "all",
+            "performance_rate_required": false
         }
     },
     {
@@ -36,7 +39,8 @@
             "name": "Invalid Code",
             "overview_text": "In this file, one of the existing codes was replaced by a code that is not valid for the value set.",
             "qrda_type": "1",
-            "measure_type": "all"
+            "measure_type": "all",
+            "performance_rate_required": false
         }
     },
     {
@@ -46,7 +50,8 @@
             "name": "Invalid Value Set",
             "overview_text": "In this file, one of the value set OIDs was replaced by an OID that is not useful for calculating this measure.",
             "qrda_type": "1",
-            "measure_type": "all"
+            "measure_type": "all",
+            "performance_rate_required": false
         }
     },
     {
@@ -56,7 +61,8 @@
             "name": "Value Set without Code System",
             "overview_text": "In this file, one of the code systems for a given value set was removed.",
             "qrda_type": "1",
-            "measure_type": "all"
+            "measure_type": "all",
+            "performance_rate_required": false
         }
     },
     {
@@ -67,7 +73,8 @@
             "overview_text": "In this file, the submitted denominator was greater than the initial patient population. In discrete eCQMs, the denominator should always be less than or equal to the initial patient population.",
             "qrda_type": "3",
             "measure_type": "discrete",
-            "tags": ["Calculation"]
+            "tags": ["Calculation"],
+            "performance_rate_required": false
         }
     },
     {
@@ -78,7 +85,8 @@
             "overview_text": "In this file, one of the measure populations (e.g., IPP, Numerator, Observed Value, etc.) was reported twice.  For a given measure, these populations should be reported once and only once.",
             "qrda_type": "3",
             "measure_type": "all",
-            "tags": ["Calculation"]
+            "tags": ["Calculation"],
+            "performance_rate_required": false
         }
     },
     {
@@ -89,7 +97,8 @@
             "overview_text": "In this file, one of populations necessary to calculate the measure was removed.",
             "qrda_type": "3",
             "measure_type": "all",
-            "tags": ["Calculation"]
+            "tags": ["Calculation"],
+            "performance_rate_required": false
         }
     },
     {
@@ -100,7 +109,8 @@
             "overview_text": "In this file, the submitted numerator was greater than the denominator.  Discrete eCQMs should be a ratio less than one.",
             "qrda_type": "3",
             "measure_type": "discrete",
-            "tags": ["Calculation"]
+            "tags": ["Calculation"],
+            "performance_rate_required": false
         }
     },
     {
@@ -111,7 +121,8 @@
             "overview_text": "In this file, the denominator in the performance rate calculation results in a divide by zero error, but the performance rate was not reported as 'NA'.",
             "qrda_type": "3",
             "measure_type": "discrete",
-            "tags": ["Calculation"]
+            "tags": ["Calculation"],
+            "performance_rate_required": true
         }
     },
     {
@@ -122,7 +133,8 @@
             "overview_text": "In this file, the performance rate was replaced with a number that is outside the acceptable range (a floating point number between 0 and 1).",
             "qrda_type": "3",
             "measure_type": "discrete",
-            "tags": ["Calculation"]
+            "tags": ["Calculation"],
+            "performance_rate_required": true
         }
     },
     {
@@ -132,7 +144,8 @@
             "name": "Invalid Measure ID",
             "overview_text": "In this file, a valid HQMF ID or HQMF Set ID was be replaced with an invalid GUID.",
             "qrda_type": "all",
-            "measure_type": "all"
+            "measure_type": "all",
+            "performance_rate_required": false
         }
     },
     {
@@ -142,7 +155,8 @@
             "name": "Inconsistent Time Formats",
             "overview_text": "In this file, one of the times was given a different format than the others.",
             "qrda_type": "all",
-            "measure_type": "all"
+            "measure_type": "all",
+            "performance_rate_required": false
         }
     },
     {
@@ -152,7 +166,8 @@
             "name": "Reporting Period",
             "overview_text": "The reporting period for this QRDA document was dated outside of the reporting year and the file should have been rejected.",
             "qrda_type": "all",
-            "measure_type": "all"
+            "measure_type": "all",
+            "performance_rate_required": false
         }
     },
     {
@@ -163,7 +178,8 @@
             "overview_text": "The latter half of this file was deleted to represent a file transfer error that would result in an unfinished QRDA file.  It should be rejected outright.",
             "qrda_type": "all",
             "measure_type": "all",
-            "tags": ["Schema"]
+            "tags": ["Schema"],
+            "performance_rate_required": false
         }
     }
 ]

--- a/lib/cypress/cat_3_calculator.rb
+++ b/lib/cypress/cat_3_calculator.rb
@@ -3,7 +3,7 @@ module Cypress
     attr_accessor :correlation_id, :measure, :bundle, :mre, :qr
 
     def initialize(measure_ids, bundle)
-      @correlation_id = BSON::ObjectId.new
+      # @correlation_id = BSON::ObjectId.new
       filter = { :hqmf_id.in => measure_ids }
       @measure = HealthDataStandards::CQM::Measure.top_level.where(filter).first
       @bundle = bundle
@@ -35,68 +35,67 @@ module Cypress
       header
     end
 
-    def generate_oid_dictionary
-      valuesets = @bundle.value_sets.in(oid: @measure.oids)
-      js = {}
-      valuesets.each do |vs|
-        js[vs.oid] = cached_value(vs)
-      end
-      js.to_json
-    end
-
-    def cached_value(vs)
-      @loaded_valuesets ||= {}
-      return @loaded_valuesets[vs.oid] if @loaded_valuesets[vs.oid]
-      js = {}
-      vs.concepts.each do |con|
-        name = con.code_system_name
-        js[name] ||= []
-        js[name] << con.code.downcase unless js[name].index(con.code.downcase)
-      end
-      @loaded_valuesets[vs.oid] = js
-      js
-    end
-
-    def import_cat1_zip(zip)
-      Zip::ZipFile.open(zip.path) do |zip_file|
-        zip_file.entries.each do |entry|
-          doc = zip_file.read(entry)
-          import_cat1_file(doc)
-        end
-      end
-    end
-
-    def import_cat1_file(doc)
-      doc = Nokogiri::XML(doc)
-      doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-      doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-      record = HealthDataStandards::Import::Cat1::PatientImporter.instance.parse_cat1(doc)
-      record.test_id = @correlation_id
-      record.medical_record_number = rand(1_000_000_000_000_000)
-      record.save
-    end
+    # def generate_oid_dictionary
+    #   valuesets = @bundle.value_sets.in(oid: @measure.oids)
+    #   js = {}
+    #   valuesets.each do |vs|
+    #     js[vs.oid] = cached_value(vs)
+    #   end
+    #   js.to_json
+    # end
+    #
+    # def cached_value(vs)
+    #   @loaded_valuesets ||= {}
+    #   return @loaded_valuesets[vs.oid] if @loaded_valuesets[vs.oid]
+    #   js = {}
+    #   vs.concepts.each do |con|
+    #     name = con.code_system_name
+    #     js[name] ||= []
+    #     js[name] << con.code.downcase unless js[name].index(con.code.downcase)
+    #   end
+    #   @loaded_valuesets[vs.oid] = js
+    #   js
+    # end
+    #
+    # def import_cat1_zip(zip)
+    #   Zip::ZipFile.open(zip.path) do |zip_file|
+    #     zip_file.entries.each do |entry|
+    #       doc = zip_file.read(entry)
+    #       import_cat1_file(doc)
+    #     end
+    #   end
+    # end
+    #
+    # def import_cat1_file(doc)
+    #   doc = Nokogiri::XML(doc)
+    #   doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+    #   doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
+    #   record = HealthDataStandards::Import::Cat1::PatientImporter.instance.parse_cat1(doc)
+    #   record.test_id = @correlation_id
+    #   record.medical_record_number = rand(1_000_000_000_000_000)
+    #   record.save
+    # end
 
     def generate_cat3(start_date, end_date)
-      ex_opts = { test_id: @correlation_id, effective_date: bundle.effective_date,
-                  enable_logging: false, enable_rationale: false }
-      filter = { hqmf_id: @measure.hqmf_id }
+      # ex_opts = { test_id: @correlation_id, effective_date: bundle.effective_date,
+      #             enable_logging: false, enable_rationale: false }
+      # filter = { hqmf_id: @measure.hqmf_id }
 
-      HealthDataStandards::CQM::Measure.where(filter).each do |measure|
-        qr = QME::QualityReport.find_or_create(measure.hqmf_id, measure.sub_id, ex_opts)
-        qr.calculate({ 'prefilter' => { test_id: @correlation_id }, oid_dictionary: generate_oid_dictionary, bundle_id: @bundle.id }, false)
-      end
+      # HealthDataStandards::CQM::Measure.where(filter).each do |measure|
+      #   # qr = QME::QualityReport.find_or_create(measure.hqmf_id, measure.sub_id, ex_opts)
+      #   # qr.calculate({ 'prefilter' => { test_id: @correlation_id }, oid_dictionary: generate_oid_dictionary, bundle_id: @bundle.id }, false)
+      # end
       exporter = HealthDataStandards::Export::Cat3.new
       # end_date = Time.at(@bundle.effective_date.to_i).utc
-
       xml = exporter.export(HealthDataStandards::CQM::Measure.top_level.where(hqmf_id: @measure.hqmf_id),
                             generate_header,
                             bundle.effective_date,
                             start_date,
                             end_date,
                             nil,
-                            @correlation_id)
-      QME::PatientCache.where(test_id: @correlation_id).destroy_all
-      HealthDataStandards::CQM::QueryCache.where(test_id: @correlation_id).destroy_all
+                            nil)
+      # QME::PatientCache.where(test_id: @correlation_id).destroy_all
+      # HealthDataStandards::CQM::QueryCache.where(test_id: @correlation_id).destroy_all
       xml
     end
   end


### PR DESCRIPTION
## QRDA 3 Performance Improvements

This branch removes most of the setup code in `cat_3_calculator` that is required for Cypress because they keep historic versions of generated Cat 3 files.  Cedar does not, so that was easy to gut.  Also, the generation of patient records and the zip-unzip-import of Cat 1 files was removed in the `test_execution` model.
## Performance Rate Filtering

To date, two of the invalidators (`performance_rate_divide_by_zero` and `performance_rate_out_of_range`) require a performance rate to be present in the QRDA file (duh).  Based on some brief research, there are two reasons that a Cedar-generated QRDA Cat 3 file might not have a performance rate:
1. Continuous measures are just that - continuous - so they don't have an expected performance rate between 0 and 1.
2. Some of the cached patients in the Cypress bundle will result in measures with a null flavor (e.g., `DENOM - DENEXCEP - DENEX = 0`)

This commit adds the `useful_measures_by_performance_rate` method to ensure that measures chosen at random for QRDA 3 generation for those invalidators will have non-null performance rates.
## TODO

A couple of low-priority bugfixes remain:
1. Add a `useful_validations_for_performance_rate` to the `test_execution` model so that if only continuous (or null-flavor performance rate) measures are selected, the performance rate invalidators will be filtered out on the validations selection screen.
2. Figure out how this can all be enforced in the API
